### PR TITLE
update contract-shield.config.json, cli.js and transpile.test.js

### DIFF
--- a/contract-shield.config.json
+++ b/contract-shield.config.json
@@ -12,5 +12,6 @@
         "**/*.config.js",
         "__tests__/**",
         "**/*.test.js"
-    ]
+    ],
+    "output": "./dist"
 }

--- a/tests/transpile.test.js
+++ b/tests/transpile.test.js
@@ -4,10 +4,10 @@ const packageJson = require('../package.json');
 
 // Cleanup helper function
 const cleanupFiles = () => {
-  const filesToRemove = ['transpile.log', 'test-config.json'];
+  const filesToRemove = ['transpile.log', 'test-config.json', 'dist', 'test-output'];
   filesToRemove.forEach(file => {
     if (fs.existsSync(file)) {
-      fs.unlinkSync(file);
+      fs.rmSync(file, { recursive: true, force: true }); // Remove files & directories
     }
   });
 };
@@ -101,5 +101,26 @@ describe('Contract Shield CLI - Basic Transpile Tests', () => {
     const output2 = execSync('node src/cli.js transpile').toString();
     expect(output1).toBeDefined();
     expect(output2).toBeDefined();
+  });
+
+  // 🔹 New Tests for `--output` Option
+  test('Transpiled files are saved in the specified output directory', () => {
+    execSync('node src/cli.js transpile --output test-output');
+
+    expect(fs.existsSync('test-output')).toBe(true);
+  });
+
+  test('Transpiled files are saved to "dist" when no --output is provided', () => {
+    execSync('node src/cli.js transpile');
+
+    expect(fs.existsSync('dist')).toBe(true);
+  });
+
+  test('Fails gracefully when given an invalid output folder', () => {
+    try {
+      execSync('node src/cli.js transpile --output "/invalid-path"');
+    } catch (error) {
+      expect(error.stderr.toString()).toBeDefined();
+    }
   });
 });


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add an `--output` option to the CLI for specifying the destination folder for transpiled files and update associated tests and config.

### Why are these changes being made?

This enhancement provides flexibility by allowing users to define where transpiled files should be saved, either to a specified directory through the `--output` option or the default "dist" directory if unspecified, facilitating better file organization. The new tests ensure robust functionality of the output feature and graceful failure on invalid paths.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->